### PR TITLE
Removed a whitespace causing a compilation failure in Ubuntu

### DIFF
--- a/src/OpenVRCameraDevice/OpenVRCamera.cpp
+++ b/src/OpenVRCameraDevice/OpenVRCamera.cpp
@@ -11,7 +11,7 @@
 #include "OpenVRCamera.h"
 #include <yarp/os/LogStream.h>
 
-#include < openvr.h>
+#include <openvr.h>
 
 // Adapted from
 // https://github.com/ValveSoftware/openvr/blob/91825305130f446f82054c1ec3d416321ace0072/samples/tracked_camera_openvr_sample/tracked_camera_openvr_sample.cpp


### PR DESCRIPTION
I reproduced the problem of https://github.com/robotology/robotology-superbuild/issues/1913 locally and this seemed to be enough to fix it